### PR TITLE
fix: whitelist master branch name from naming check hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "husky": {
     "hooks": {
-      "post-checkout": "branch-naming-check '^\\d+(-[a-z]+)+$'",
-      "pre-commit": "branch-naming-check '^\\d+(-[a-z]+)+$' && npm run lint:file-folder-convention",
+      "post-checkout": "branch-naming-check '^\\d+(-[a-z]+)+|master$'",
+      "pre-commit": "branch-naming-check '^\\d+(-[a-z]+)+|master$' && npm run lint:file-folder-convention",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },


### PR DESCRIPTION
Closes #110 